### PR TITLE
Optimalizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 env.json
 .homeybuild/
 node_modules/
+AGENTS.md

--- a/.homeycompose/flow/conditions/connected.json
+++ b/.homeycompose/flow/conditions/connected.json
@@ -21,7 +21,7 @@
     {
       "type": "device",
       "name": "device",
-      "filter": "driver_id=senz&capabilities=connected"
+      "filter": "driver_id=senz&capabilities=alarm_connectivity"
     }
   ]
 }

--- a/.homeycompose/flow/triggers/connected_false.json
+++ b/.homeycompose/flow/triggers/connected_false.json
@@ -21,7 +21,7 @@
     {
       "type": "device",
       "name": "device",
-      "filter": "driver_id=senz&capabilities=connected"
+      "filter": "driver_id=senz&capabilities=alarm_connectivity"
     }
   ]
 }

--- a/.homeycompose/flow/triggers/connected_true.json
+++ b/.homeycompose/flow/triggers/connected_true.json
@@ -21,7 +21,7 @@
     {
       "type": "device",
       "name": "device",
-      "filter": "driver_id=senz&capabilities=connected"
+      "filter": "driver_id=senz&capabilities=alarm_connectivity"
     }
   ]
 }

--- a/app.json
+++ b/app.json
@@ -242,7 +242,7 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=senz&capabilities=connected"
+            "filter": "driver_id=senz&capabilities=alarm_connectivity"
           }
         ],
         "id": "connected_false"
@@ -270,7 +270,7 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=senz&capabilities=connected"
+            "filter": "driver_id=senz&capabilities=alarm_connectivity"
           }
         ],
         "id": "connected_true"
@@ -495,7 +495,7 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=senz&capabilities=connected"
+            "filter": "driver_id=senz&capabilities=alarm_connectivity"
           }
         ],
         "id": "connected"

--- a/lib/App.js
+++ b/lib/App.js
@@ -269,7 +269,7 @@ class App extends OAuth2App {
     // Condition flow cards
     // ... and connected is ...
     this.homey.flow.getConditionCard('connected').registerRunListener(async ({ device }) => {
-      return device.getCapabilityValue('connected') === true;
+      return device.getCapabilityValue('alarm_connectivity') === false;
     });
 
     // ... and heating is ...

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -8,7 +8,7 @@ class Client extends OAuth2Client {
   static API_URL = 'https://api.senzthermostat.chemelex.com';
   static TOKEN_URL = 'https://id.senzthermostat.chemelex.com/connect/token';
   static AUTHORIZATION_URL = 'https://id.senzthermostat.chemelex.com/connect/authorize';
-  static SCOPES = ['offline_access', 'restapi'];
+  static SCOPES = ['openid', 'offline_access', 'restapi'];
 
   /*
   | Device functions
@@ -96,8 +96,10 @@ class Client extends OAuth2Client {
     }
 
     // Custom error message
-    if (filled(body.Messages) && filled(body.Messages[0])) {
-      error = new Error(body.Messages[0]);
+    const messages = body?.messages || body?.Messages;
+
+    if (filled(messages) && filled(messages[0])) {
+      error = new Error(messages[0]);
     }
 
     // Unknown error

--- a/lib/Device.js
+++ b/lib/Device.js
@@ -280,14 +280,14 @@ class Device extends OAuth2Device {
   async migrate() {
     // Remove 'connected' capability
     if (this.hasCapability('connected')) {
-      this.removeCapability('connected').catch(this.error);
+      await this.removeCapability('connected');
 
       this.log('Capability `connected` removed');
     }
 
     // Add 'alarm_connectivity' capability
     if (!this.hasCapability('alarm_connectivity')) {
-      this.addCapability('alarm_connectivity').catch(this.error);
+      await this.addCapability('alarm_connectivity');
 
       this.log('Capability `alarm_connectivity` added');
     }

--- a/lib/Device.js
+++ b/lib/Device.js
@@ -75,7 +75,9 @@ class Device extends OAuth2Device {
       // Synchronize data
       await this.syncCapabilityValues(data);
 
-      this.setAvailable().catch(this.error);
+      // Keep the device available, but surface API-reported offline state on the tile.
+      await this.syncWarningState(data);
+      await this.setAvailable();
     } catch (err) {
       this.error('[Sync]', err.message);
       this.setUnavailable(this.homey.__(err.message)).catch(this.error);
@@ -95,6 +97,16 @@ class Device extends OAuth2Device {
     }
 
     data = null;
+  }
+
+  // Set or clear warning state based on connectivity.
+  async syncWarningState(data) {
+    if (data.alarm_connectivity === true) {
+      await this.setWarning(this.homey.__('error.offline'));
+      return;
+    }
+
+    await this.unsetWarning();
   }
 
   /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,25 +15,25 @@
       ],
       "license": "SEE LICENSE",
       "dependencies": {
-        "@microsoft/signalr": "^7.0.5",
+        "@microsoft/signalr": "^10.0.0",
         "collect.js": "^4.36.1",
-        "homey-oauth2app": "^3.7.0"
+        "homey-oauth2app": "^3.7.2"
       },
       "devDependencies": {
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12"
       }
     },
     "node_modules/@microsoft/signalr": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-7.0.14.tgz",
-      "integrity": "sha512-dnS7gSJF5LxByZwJaj82+F1K755ya7ttPT+JnSeCBef3sL8p8FBkHePXphK8NSuOquIb7vsphXWa28A+L2SPpw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-10.0.0.tgz",
+      "integrity": "sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "eventsource": "^2.0.2",
         "fetch-cookie": "^2.0.3",
         "node-fetch": "^2.6.7",
-        "ws": "^7.4.5"
+        "ws": "^7.5.10"
       }
     },
     "node_modules/@types/homey": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "url": "https://github.com/edwinvdpol/homey-nvent.git"
   },
   "dependencies": {
-    "@microsoft/signalr": "^7.0.5",
+    "@microsoft/signalr": "^10.0.0",
     "collect.js": "^4.36.1",
-    "homey-oauth2app": "^3.7.0"
+    "homey-oauth2app": "^3.7.2"
   },
   "devDependencies": {
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12"


### PR DESCRIPTION
Fixed connected capability migration race by awaiting removal/addition and updated legacy flow cards/filters to use alarm_connectivity, eliminating the startup Invalid Capability: connected errors.

> 2026-04-05T18:14:46.922Z [err] [ManagerDrivers] [Driver:senz] [Device:fb723785-9fac-4822-8d8e-82cfa957bbea] Error: Invalid Capability: connected
>     at Remote Process
>     at HomeyClient.emit (/app/packages/homey-local/lib/AppProcess/node_modules/@athombv/homey-apps-sdk-v3/lib/HomeyClient.js:44:23)
>     at Object.emit (/app/packages/homey-local/lib/AppProcess/node_modules/@athombv/homey-apps-sdk-v3/manager/drivers.js:78:54)
>     at Object.emit (/app/packages/homey-local/lib/AppProcess/node_modules/@athombv/homey-apps-sdk-v3/lib/Driver.js:126:50)
>     at SenzDevice.addCapability (/app/packages/homey-local/lib/AppProcess/node_modules/@athombv/homey-apps-sdk-v3/lib/Device.js:460:25)
>     at SenzDevice.migrate (/app/lib/Device.js:290:12)
>     at SenzDevice.onOAuth2Init (/app/lib/Device.js:33:16)
>     at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
>     at async SenzDevice.onInit (/app/node_modules/homey-oauth2app/lib/OAuth2Device.js:98:5)
>     at async SenzDevice._onInit (/app/packages/homey-local/lib/AppProcess/node_modules/@athombv/homey-apps-sdk-v3/lib/Device.js:156:7) {
>   statusCode: 404
> }